### PR TITLE
Remove image urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Self Contained Automated Test Environment
 
 2. Install the Vagrant plugins:
    ```
-	      vagrant plugin install vagrant-aws
+	vagrant plugin install vagrant-aws  --plugin-version '== 0.5.0'
         vagrant plugin install vagrant-berkshelf --plugin-version '>= 2.0.1'
         vagrant plugin install vagrant-omnibus
    ```
@@ -52,10 +52,6 @@ Self Contained Automated Test Environment
     override.ssh.private_key_path ="/Users/viglesias/.ssh/id_rsa"
     ```
 
-6. Install a "dummy" vagrant box file to allow override of the box with the ami/emi:
-   ```
-   vagrant box add centos https://github.com/mitchellh/vagrant-aws/raw/master/dummy.box
-   ```
 6. Once inside the repository run "vagrant up --provider=aws". This will run a virtual machine, and install MicroQA in your cloud.
 
 7. Login to MicroQA on your browser by visiting: http://\<instance-ip\>:8080

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,62 +4,62 @@ options = {
   :cores => 2,
   :memory => 3000,
 }
-Vagrant.configure("2") do |config|
-    config.vm.box = "chef/centos-6.6"
-    config.vm.hostname = "micro-qa"
-    config.vm.synced_folder ".", "/vagrant", owner: "root", group: "root"
+Vagrant.configure('2') do |config|
+    config.vm.box = 'chef/centos-6.6'
+    config.vm.hostname = 'micro-qa'
+    config.vm.synced_folder '.', '/vagrant', owner: 'root', group: 'root'
     config.vm.provider :aws do |aws, override|
-        override.vm.box_url = "https://github.com/mitchellh/vagrant-aws/raw/master/dummy.box"
+        override.vm.box_url = 'https://github.com/mitchellh/vagrant-aws/raw/master/dummy.box'
         override.ssh.pty = true
-        override.ssh.private_key_path = "~/.ssh/id_rsa"
-        aws.access_key_id = "DWDWTCOBHXXXXXXXXXXXXX"
-        aws.secret_access_key = "D1eKhnWw2wUfeOvKNMVQYYYYYYYYYYYYYY"
-        aws.instance_type = "m1.xlarge"
-        aws.ami = "emi-A6EA57D5"
-        aws.security_groups = ["default"]
+        override.ssh.private_key_path = '~/.ssh/id_rsa'
+        aws.access_key_id = 'DWDWTCOBHXXXXXXXXXXXXX'
+        aws.secret_access_key = 'D1eKhnWw2wUfeOvKNMVQYYYYYYYYYYYYYY'
+        aws.instance_type = 'm1.xlarge'
+        aws.ami = 'emi-A6EA57D5'
+        aws.security_groups = ['default']
         aws.instance_ready_timeout = 600
-        aws.endpoint = "http://my-clc-ip:8773/services/Eucalyptus"
-        aws.keypair_name = "my-keypair"
-        override.ssh.username ="root"
-        aws.user_data = File.read("user_data.txt")
+        aws.endpoint = 'http://my-clc-ip:8773/services/Eucalyptus'
+        aws.keypair_name = 'my-keypair'
+        override.ssh.username ='root'
+        aws.user_data = File.read('user_data.txt')
         aws.block_device_mapping = [
         {
-            :DeviceName => "/dev/sda",
-            "Ebs.VolumeSize" => 10
+            :DeviceName => '/dev/sda',
+            'Ebs.VolumeSize' => 10
         }]
         aws.tags = {
-                Name: "Micro QA",
+                Name: 'Micro QA',
         }
     end
     config.vm.network :forwarded_port, guest: 8080, host: 8080
     config.vm.provider :vmware_fusion do |v, override|
-        override.vm.network "public_network"
-        if config.vm.box == "centos"
-          override.vm.box_url = "https://dl.dropbox.com/u/5721940/vagrant-boxes/vagrant-centos-6.4-x86_64-vmware_fusion.box"
+        override.vm.network 'public_network'
+        if config.vm.box == 'centos'
+          override.vm.box_url = 'https://dl.dropbox.com/u/5721940/vagrant-boxes/vagrant-centos-6.4-x86_64-vmware_fusion.box'
         else
-          override.vm.box_url = "http://grahamc.com/vagrant/ubuntu-12.04.2-server-amd64-vmware-fusion.box"
+          override.vm.box_url = 'http://grahamc.com/vagrant/ubuntu-12.04.2-server-amd64-vmware-fusion.box'
         end
-        v.vmx["memsize"] = options[:memory].to_i
-        v.vmx["numvcpus"] = options[:cores].to_i
-        v.vmx["vhv.enable"] = "true"
+        v.vmx['memsize'] = options[:memory].to_i
+        v.vmx['numvcpus'] = options[:cores].to_i
+        v.vmx['vhv.enable'] = 'true'
     end
     config.vm.provider :virtualbox do |v, override|
-        override.vm.network "public_network"
-        if config.vm.box == "chef/centos-6.6"
-          override.vm.box_url = "https://atlas.hashicorp.com/chef/boxes/centos-6.6"
+        override.vm.network 'public_network'
+        if config.vm.box == 'chef/centos-6.6'
+          override.vm.box_url = 'https://atlas.hashicorp.com/chef/boxes/centos-6.6'
         end
-        v.customize [ "modifyvm", :id, "--memory", options[:memory].to_i, "--cpus", options[:cores].to_i]
+        v.customize [ 'modifyvm', :id, '--memory', options[:memory].to_i, '--cpus', options[:cores].to_i]
     end
     config.omnibus.chef_version = :latest
     config.berkshelf.enabled = true
     config.vm.provision :chef_solo do |chef|
-      chef.add_recipe "micro-qa::jenkins"
-      chef.add_recipe "micro-qa::eutester"
-      chef.add_recipe "micro-qa::console-tests"
-      chef.add_recipe "micro-qa::deploy"
+      chef.add_recipe 'micro-qa::jenkins'
+      chef.add_recipe 'micro-qa::eutester'
+      chef.add_recipe 'micro-qa::console-tests'
+      chef.add_recipe 'micro-qa::deploy'
       chef.json = {}
     end
-    if Vagrant.has_plugin?("vagrant-cachier")
+    if Vagrant.has_plugin?('vagrant-cachier')
       config.cache.scope = :box
     end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -33,20 +33,12 @@ Vagrant.configure('2') do |config|
     config.vm.network :forwarded_port, guest: 8080, host: 8080
     config.vm.provider :vmware_fusion do |v, override|
         override.vm.network 'public_network'
-        if config.vm.box == 'centos'
-          override.vm.box_url = 'https://dl.dropbox.com/u/5721940/vagrant-boxes/vagrant-centos-6.4-x86_64-vmware_fusion.box'
-        else
-          override.vm.box_url = 'http://grahamc.com/vagrant/ubuntu-12.04.2-server-amd64-vmware-fusion.box'
-        end
         v.vmx['memsize'] = options[:memory].to_i
         v.vmx['numvcpus'] = options[:cores].to_i
         v.vmx['vhv.enable'] = 'true'
     end
     config.vm.provider :virtualbox do |v, override|
         override.vm.network 'public_network'
-        if config.vm.box == 'chef/centos-6.6'
-          override.vm.box_url = 'https://atlas.hashicorp.com/chef/boxes/centos-6.6'
-        end
         v.customize [ 'modifyvm', :id, '--memory', options[:memory].to_i, '--cpus', options[:cores].to_i]
     end
     config.omnibus.chef_version = :latest

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,6 @@ Vagrant.configure('2') do |config|
     config.vm.synced_folder '.', '/vagrant', owner: 'root', group: 'root'
     config.vm.provider :aws do |aws, override|
         override.vm.box_url = 'https://github.com/mitchellh/vagrant-aws/raw/master/dummy.box'
-        override.ssh.pty = true
         override.ssh.private_key_path = '~/.ssh/id_rsa'
         aws.access_key_id = 'DWDWTCOBHXXXXXXXXXXXXX'
         aws.secret_access_key = 'D1eKhnWw2wUfeOvKNMVQYYYYYYYYYYYYYY'

--- a/user_data.txt
+++ b/user_data.txt
@@ -8,6 +8,8 @@ Content-Transfer-Encoding: 7bit
 Content-Disposition: attachment; filename="script.sh"
 
 #!/bin/bash
+sed -i 's/Defaults.*requiretty/#Defaults requiretty/g' /etc/sudoers
+iptables -F
 SWAP_FILE=/tmp/swap
 dd if=/dev/zero of=$SWAP_FILE bs=1M count=2000
 mkswap $SWAP_FILE


### PR DESCRIPTION
We no longer need to call out specific urls since Vagrant now allows namespacing and the use of Vagrantcloud.

This includes the changes from fix-cloud as well.
